### PR TITLE
Changed card links on a2.stories.mdx

### DIFF
--- a/src/4-components/a2-alerts/a2.stories.mdx
+++ b/src/4-components/a2-alerts/a2.stories.mdx
@@ -58,7 +58,7 @@ import LinkTo from "@storybook/addon-links/react";
 						<div className="act-col__cw-12">
 							<div className="act-box">
 								<div className="act-card-grid">
-									<LinkTo className="act-card act-card__primary act-card__feature--icon" kind="components-alerts-global-alert-guidance--page">
+									<LinkTo className="act-card act-card__primary act-card__feature--icon" kind="components-alerts-global-alert--global-alert">
 										<div class="act-card__container">
 											<div class="act-card__content">
 												<div class="act-card__icon">
@@ -72,7 +72,7 @@ import LinkTo from "@storybook/addon-links/react";
 											</div>
 										</div>
 									</LinkTo>
-									<LinkTo className="act-card act-card__primary act-card__feature--icon" kind="components-alerts-global-alert--global-alert">
+									<LinkTo className="act-card act-card__primary act-card__feature--icon" kind="components-alerts-in-page-alert--in-page-alert">
 										<div class="act-card__container">
 											<div class="act-card__content">
 												<div class="act-card__icon">


### PR DESCRIPTION
Changed the global alert card link to go to the component instead of the guidance, and fixed the in page alert card which was linking to the global alert component.