### PR TITLE
Changed tag hover state to have outline instead of border

### DIFF
--- a/src/4-components/c1-cards/c1-style.scss
+++ b/src/4-components/c1-cards/c1-style.scss
@@ -266,7 +266,7 @@
 				}
 			}
 			.act-tag {
-				border: 1px solid $act-colour__white;
+				outline: 1px solid $act-colour__white;
 				&__stroke {
 					background: none;
 					color: $act-colour__white;


### PR DESCRIPTION
To fix a bug where, when hovering on a card with tags, the contents gets shifted down because of the border on the tags.