### PR TITLE
Changed the quick exit link to go to Google instead of BOM

### DIFF
--- a/src/_scripts/spf3.js
+++ b/src/_scripts/spf3.js
@@ -680,8 +680,8 @@ function initQuickExit() {
 		quickExitToggle.addEventListener("click", function(e) {
 			e.preventDefault();
 			html.remove();
-			window.open("http://www.bom.gov.au/", "_blank");
-			window.location.replace("http://www.bom.gov.au/");
+			window.open("https://www.google.com.au", "_blank");
+			window.location.replace("https://www.google.com.au");
 		});
 	}
 }


### PR DESCRIPTION
The quick exit was going to the BOM website, changing it to go to google